### PR TITLE
Fixes error 129 placement

### DIFF
--- a/server/k8s/utils/pod_exec.go
+++ b/server/k8s/utils/pod_exec.go
@@ -32,6 +32,11 @@ func PodExec(client *kubernetes.Clientset, config *rest.Config, w io.Writer, nam
 	url := req.URL()
 
 	exec, err := remotecommand.NewExecutor(config, "POST", url)
+	if err != nil {
+		return err
+	}
+
+	err = exec.Stream(opts)
 	// This is not the most ideal way to handle the error since its tied to a specfic string.
 	// This appears to be an error from Docker.
 	// https://github.com/docker/compose/issues/3379
@@ -40,5 +45,5 @@ func PodExec(client *kubernetes.Clientset, config *rest.Config, w io.Writer, nam
 		return err
 	}
 
-	return exec.Stream(opts)
+	return nil
 }


### PR DESCRIPTION
#### What does this PR do?

Moves the "error 129 for PHP containers" check to further in the error return.

#### How should this be manually tested?

Can be tested by writing a simple program with "pod_exec.go" code and executing against a running K8s cluster + PHP pod.

#### Any background context you want to provide?

N/A

#### What are the relevant tickets?

N/A

#### Screenshots (if appropriate)

N/A

#### Questions:

##### Does any external documentation require updating?

N/A

##### Does this changeset require specific versions of supporting software?
(i.e. Go / Terraform / Docker)

N/A