### PR TITLE
Adds private registry support

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -38,6 +38,8 @@ type cmdServer struct {
 
 	PrometheusPort string
 	PrometheusPath string
+
+	DockerCfg string
 }
 
 func (cmd *cmdServer) run(c *kingpin.ParseContext) error {
@@ -70,6 +72,7 @@ func (cmd *cmdServer) run(c *kingpin.ParseContext) error {
 		Config:    config,
 		Token:     cmd.Token,
 		Namespace: cmd.Namespace,
+		DockerCfg: cmd.DockerCfg,
 		Cache: server.InputCache{
 			Directories: cmd.CacheDirectories,
 			Type:        cmd.CacheType,
@@ -133,6 +136,9 @@ func Server(app *kingpin.Application) {
 	// Promtheus.
 	cmd.Flag("prometheus-port", "Prometheus metrics port").Default(":9000").OverrideDefaultFromEnvar("M8S_METRICS_PORT").StringVar(&c.PrometheusPort)
 	cmd.Flag("prometheus-path", "Prometheus metrics path").Default("/metrics").OverrideDefaultFromEnvar("M8S_METRICS_PATH").StringVar(&c.PrometheusPath)
+
+	// Docker Registry.
+	cmd.Flag("dockercfg", "https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry").Default("").Envar("M8S_DOCKERCFG").StringVar(&c.DockerCfg)
 }
 
 // Helper function for serving Prometheus metrics.

--- a/server/k8s/env/pod.go
+++ b/server/k8s/env/pod.go
@@ -14,14 +14,15 @@ import (
 
 // PodInput provides the Pod function with information to produce a Kubernetes Pod.
 type PodInput struct {
-	Namespace   string
-	Name        string
-	Annotations []*pb.Annotation
-	Repository  string
-	Revision    string
-	Retention   string
-	Services    []*pb.ComposeService
-	Caches      []PodInputCache
+	Namespace       string
+	Name            string
+	Annotations     []*pb.Annotation
+	Repository      string
+	Revision        string
+	Retention       string
+	Services        []*pb.ComposeService
+	Caches          []PodInputCache
+	ImagePullSecret string
 }
 
 // PodInputCache is used for passing in cache configuration to generate a pod.
@@ -71,6 +72,14 @@ func Pod(input PodInput) (*v1.Pod, error) {
 				},
 			},
 		},
+	}
+
+	if input.ImagePullSecret != "" {
+		pod.Spec.ImagePullSecrets = []v1.LocalObjectReference{
+			{
+				Name: input.ImagePullSecret,
+			},
+		}
 	}
 
 	for _, cache := range input.Caches {

--- a/server/k8s/env/pod_test.go
+++ b/server/k8s/env/pod_test.go
@@ -177,6 +177,11 @@ func TestPod(t *testing.T) {
 					},
 				},
 			},
+			ImagePullSecrets: []v1.LocalObjectReference{
+				{
+					Name: "super_secret",
+				},
+			},
 		},
 	}
 
@@ -184,11 +189,12 @@ func TestPod(t *testing.T) {
 	assert.Nil(t, err)
 
 	have, err := Pod(PodInput{
-		Namespace:   "test",
-		Name:        "pr1",
-		Annotations: annotations,
-		Repository:  "git@github.com:foo/bar.git",
-		Revision:    "123456789",
+		Namespace:       "test",
+		Name:            "pr1",
+		Annotations:     annotations,
+		Repository:      "git@github.com:foo/bar.git",
+		Revision:        "123456789",
+		ImagePullSecret: "super_secret",
 		Services: []*pb.ComposeService{
 			{
 				Name:  "app",

--- a/server/server.go
+++ b/server/server.go
@@ -13,6 +13,7 @@ type Input struct {
 	Config    *rest.Config
 	Token     string
 	Namespace string
+	DockerCfg string
 	SSH       string
 	Cache     InputCache
 }
@@ -31,6 +32,7 @@ func New(input Input) (Server, error) {
 		config:    input.Config,
 		Token:     input.Token,
 		Namespace: input.Namespace,
+		DockerCfg: input.DockerCfg,
 		Cache: Cache{
 			Type: input.Cache.Type,
 			Size: input.Cache.Size,

--- a/server/types.go
+++ b/server/types.go
@@ -11,6 +11,7 @@ type Server struct {
 	config     *rest.Config
 	Token      string
 	Namespace  string
+	DockerCfg  string
 	SSHService string
 	Cache      Cache
 }


### PR DESCRIPTION
#### What does this PR do?

* Adds private registry support
* Leave registry secrets for Operators to administer (only declare in the server)

#### How should this be manually tested?

* Create a image pull secret https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry
* Deploy this API
* Use the environment variable "M8S_DOCKERCFG" to identify your secret

#### Any background context you want to provide?

* Pulling private images eg. Mysql backups

#### What are the relevant tickets?

N/A

#### Screenshots (if appropriate)


N/A

#### Questions:

##### Does any external documentation require updating?

We can lean on the Kubernetes docs

##### Does this changeset require specific versions of supporting software?
(i.e. Go / Terraform / Docker)

N/A